### PR TITLE
Correct data errors with DateEnd

### DIFF
--- a/california_midasapi/types.py
+++ b/california_midasapi/types.py
@@ -32,15 +32,14 @@ class ValueInfoItem:
     __endDateTime = None
     def GetEnd(self) -> datetime:
         """Get the end of this tariff as a python datetime"""
-        startDate = parser.parse(self.DateStart)
-        endDate = parser.parse(self.DateEnd)
-
         if self.__endDateTime is None:
             self.__endDateTime = parser.parse(f"{self.DateEnd} {self.TimeEnd}Z")
 
-        """Correct end dates that incorrectly cross over into next day"""
-        if endDate - startDate <= timedelta(days=1) and self.DayStart == self.DayEnd:
-            self.__endDateTime = parser.parse(f"{self.DateStart} {self.TimeEnd}Z")
+            """Correct end dates that incorrectly cross over into next day (#1)"""
+            startDate = parser.parse(self.DateStart)
+            endDate = parser.parse(self.DateEnd)
+            if endDate - startDate == timedelta(days=1) and self.DayStart == self.DayEnd:
+                self.__endDateTime = parser.parse(f"{self.DateStart} {self.TimeEnd}Z")
 
         return self.__endDateTime
 

--- a/california_midasapi/types.py
+++ b/california_midasapi/types.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass, field
 from typing import Optional
-from datetime import datetime
+from datetime import datetime, timedelta
 from dateutil import parser
 
 @dataclass
@@ -32,8 +32,16 @@ class ValueInfoItem:
     __endDateTime = None
     def GetEnd(self) -> datetime:
         """Get the end of this tariff as a python datetime"""
+        startDate = parser.parse(self.DateStart)
+        endDate = parser.parse(self.DateEnd)
+
         if self.__endDateTime is None:
             self.__endDateTime = parser.parse(f"{self.DateEnd} {self.TimeEnd}Z")
+
+        """Correct end dates that incorrectly cross over into next day"""
+        if endDate - startDate <= timedelta(days=1) and self.DayStart == self.DayEnd:
+            self.__endDateTime = parser.parse(f"{self.DateStart} {self.TimeEnd}Z")
+
         return self.__endDateTime
 
 @dataclass


### PR DESCRIPTION
When I started using this a few months ago (as part of the Home Assistant integration), I found that bad data was being inserted by SDGE into the rate table. Specifically, the time range corresponding to the *end* of a UTC day is incorrectly setting the `DateEnd` value to the *next* date, e.g.
```
ValueInfoItem(
  ValueName='TOUDR1 WINTER OFF',
  DateStart='2024-12-10',
  DateEnd='2024-12-11',
  DayStart='Tuesday',
  DayEnd='Tuesday',
  TimeStart='23:00:00',
  TimeEnd='23:59:59',
  value=0.49928,
  Unit='$/kWh'
)
```
Since this incorrect data crosses a date boundary, it winds up being part of the filtered list returned from `GetActiveTariffs` and the resulting incorrect tariff is always first in the list.

I reached out to SDGE several times starting in early September, requesting a fix for this but have yet to hear back.  Ideally it would be nice to get this fixed at the source, but given the current situation, I thought it might make sense to correct these obviously invalid items ourselves.